### PR TITLE
Fix: don't want to use insecure ip without san cert

### DIFF
--- a/manifests/release-insecure/kustomization.yaml
+++ b/manifests/release-insecure/kustomization.yaml
@@ -1,0 +1,11 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../base
+patchesStrategicMerge:
+  - patch.yaml
+images:
+  - name: gcr.io/k8s-staging-metrics-server/metrics-server
+    newName: k8s.gcr.io/metrics-server/metrics-server
+    newTag: v0.4.1
+

--- a/manifests/release-insecure/patch.yaml
+++ b/manifests/release-insecure/patch.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: metrics-server
+  namespace: kube-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: metrics-server
+          args:
+          - --kubelet-preferred-address-types=InternalIP
+          - --kubelet-insecure-tls

--- a/manifests/release-insecure/patch.yaml
+++ b/manifests/release-insecure/patch.yaml
@@ -10,5 +10,7 @@ spec:
       containers:
         - name: metrics-server
           args:
+          - --cert-dir=/tmp
+          - --secure-port=4443
           - --kubelet-preferred-address-types=InternalIP
           - --kubelet-insecure-tls


### PR DESCRIPTION
This is required because of a deficiency of my cluster, it does not have an appropriate IP SAN in the certificate and it does not have a canonical DNS name for the Kubernetes API certificates to be identified at (the cluster name is the machine hostname, just "moo").

This could be fixed with a cluster DNS name, hopefully from the private zone moo.nerdland.local

Or fixed by setting a SAN IP in the certificate on my cluster. Both would require rebuilding the cluster so we can try it later.